### PR TITLE
Fix HAR output issue

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
@@ -2,6 +2,7 @@ package com.chuckerteam.chucker.internal.data.har.log.entry
 
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.har.log.entry.response.Content
+import com.chuckerteam.chucker.internal.data.har.log.entry.response.Content.Companion.EMPTY
 import com.google.gson.annotations.SerializedName
 
 // https://github.com/ahmadnassri/har-spec/blob/master/versions/1.2.md#response
@@ -24,7 +25,7 @@ internal data class Response(
         statusText = transaction.responseMessage ?: "",
         httpVersion = transaction.protocol ?: "",
         headers = transaction.getParsedResponseHeaders()?.map { Header(it) } ?: emptyList(),
-        content = transaction.responsePayloadSize?.run { Content(transaction) },
+        content = transaction.responsePayloadSize?.run { Content(transaction) } ?: EMPTY,
         headersSize = transaction.responseHeadersSize ?: 0,
         bodySize = transaction.getHarResponseBodySize(),
         totalSize = transaction.getResponseTotalSize()

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/response/Content.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/response/Content.kt
@@ -13,6 +13,15 @@ internal data class Content(
     @SerializedName("encoding") val encoding: String? = null,
     @SerializedName("comment") val comment: String? = null
 ) {
+
+    companion object {
+        internal val EMPTY = Content(
+            size = 0L,
+            compression = 0,
+            mimeType = "text/plain",
+            text = ""
+        )
+    }
     constructor(transaction: HttpTransaction) : this(
         size = transaction.responsePayloadSize,
         mimeType = transaction.responseContentType ?: "application/octet-stream",


### PR DESCRIPTION
It looks like the HAR conversion code doesn't properly create a response entry object when the response body was empty. In this case, the `content` object is still required to be present but is currently omitted. This fixes the issue so HAR files pass validation and can be opened through tools like the Chromium Network Panel debug tool 
